### PR TITLE
Use Determinate Nix Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It automatically:
 - Installs required Ansible collections (`community.general`)
 - Ensures `.zshrc` and `.config/` exist
 - Installs `zsh` (on Linux) and sets it as the default shell
-- Installs Nix (if missing)
+- Installs Nix via the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer) if missing
 - Clones and updates your Nix config repo (based on OS)
 - Installs Raycast (on macOS, via Homebrew Cask)
 
@@ -136,6 +136,7 @@ This helps with debugging or reviewing the full install process.
 # References
 
 - [Nix Installation](https://nixos.org/download.html)
+- [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer)
 - [Homebrew](https://brew.sh/)
 - [Ansible Documentation](https://docs.ansible.com/)
 - [Raycast](https://www.raycast.com/)

--- a/lab-rat-user-reset.sh
+++ b/lab-rat-user-reset.sh
@@ -9,6 +9,21 @@ if [[ "$EUID" -ne 0 ]]; then
   exit 1
 fi
 
+# Remove any existing Nix installation
+if [ -d /nix ]; then
+  echo "🗑️ Removing existing Nix installation..."
+  if [ -x /nix/nix-installer ]; then
+    /nix/nix-installer uninstall --no-confirm || /nix/nix-installer uninstall || true
+  else
+    # Fallback manual cleanup for unknown install method
+    launchctl remove org.nixos.nix-daemon 2>/dev/null || true
+    rm -rf /nix
+    dscl . -delete /Users/nixbld 2>/dev/null || true
+    dscl . -delete /Groups/nixbld 2>/dev/null || true
+    rm -f /etc/profile.d/nix.sh /etc/paths.d/nix
+  fi
+fi
+
 USERNAME="labrat"
 FULLNAME="Lab Rat Test User"
 USER_HOME="/Users/$USERNAME"

--- a/playbook.yml
+++ b/playbook.yml
@@ -71,12 +71,12 @@
         path: /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       register: nix_env_initialized
 
-    - name: 🍎 Install Nix (macOS)
+    - name: 🍎 Install Nix (macOS with Determinate Nix Installer)
       when: is_macos and not nix_env_initialized.stat.exists
       shell: |
-        sh <(curl -L https://nixos.org/nix/install) --daemon
+        curl -fsSL https://install.determinate.systems/nix | sh -s -- install --no-confirm
       args:
-        executable: /bin/zsh
+        executable: /bin/bash
       register: nix_install_result
       failed_when: nix_install_result.rc != 0
 
@@ -88,10 +88,10 @@
         create: yes
         insertafter: EOF
 
-    - name: 🐧 Install Nix (Linux)
+    - name: 🐧 Install Nix (Linux with Determinate Nix Installer)
       when: is_linux and not nix_env_initialized.stat.exists
       shell: |
-        sh <(curl -L https://nixos.org/nix/install) --daemon
+        curl -fsSL https://install.determinate.systems/nix | sh -s -- install --no-confirm
       args:
         executable: /bin/bash
 


### PR DESCRIPTION
## Summary
- install Nix via Determinate Nix Installer on macOS and Linux
- mention new installer in README references
- update description bullet about Nix install
- add cleanup of existing Nix install in lab-rat script

## Testing
- `shellcheck bootstrap-macos.sh bootstrap-linux.sh lab-rat-user-reset.sh`
- `ansible-lint playbook.yml` *(fails: couldn't resolve community.general.homebrew)*


------
https://chatgpt.com/codex/tasks/task_e_686edc86026c832491d68e8a03fe6707